### PR TITLE
Bugfix/encoding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,8 @@
+# 0.0.1 
+
+ * issue#4 encoding fixed to utf-8
+ * improve test coverage
+ * add context menu to rename specific duplicate files
+ * add codecov support
+ * add travis-ci support
+ * initial project setup

--- a/src/main/java/de/b0n/dir/processor/DuplicateLengthFinder.java
+++ b/src/main/java/de/b0n/dir/processor/DuplicateLengthFinder.java
@@ -37,7 +37,7 @@ public class DuplicateLengthFinder implements Callable<Queue<FileSize>>  {
 
 	private void containsElementsCheck() {
 		if (folder.list() == null) {
-			throw new IllegalArgumentException("Pfad enth‰lt keine Elemente: " + folder.getAbsolutePath());
+			throw new IllegalArgumentException("Pfad enth√§lt keine Elemente: " + folder.getAbsolutePath());
 		}
 	}
 


### PR DESCRIPTION
War scheinbar nur ein ä im falschen Encoding und evtl. hat es die Zeilenumbrüche noch automatisch korrigiert beim commit - git meinte sowas von das wäre notwendig ?-)
